### PR TITLE
Replace Releaser association mechanism through PVC with a Storage Class annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-12-11
+
+### BREAKING CHANGES
+
+Prior to this change, one of the features of Releaser was to "Automatically associates Releaser with PVs claimed by PVCs that were created by Provisioner with the same `--controller-id`".
+From the `README.md` prior to this change:
+
+> ## PV Releaser Controller
+> 
+> For Releaser to be able to make PVs claimed by Provisioner `Available` after PVC is gone - Releaser and Provisioner must share the same Controller ID.
+> 
+> ### Associate
+> 
+> Once `Released` - PVs doesn't have any indication that they were once associated with a PVC that had association with this Controller ID. To establish this relation - we must catch it while PVC still exists and mark it with our label. If Releaser was down the whole time PVC existed - PV could never be associated making it now orphaned and it will stay as `Released` - Releaser can't know it have to make it `Available`.
+> 
+> Releaser listens for PV creations/updates.
+> The following conditions must be met for a PV to be associated with a Releaser:
+> 
+> - PV doesn't already have `metadata.labels."reclaimable-pv-releaser.kubernetes.io/managed-by"` association.
+> - `spec.claimRef` must refer to a PVC that either has `metadata.labels."dynamic-pvc-provisioner.kubernetes.io/managed-by"` or `reclaimable-pv-releaser.kubernetes.io/managed-by` set to this Controller ID. If both labels are set - both should point to this Controller ID.
+> - `--disable-automatic-association` must be `false`.
+> 
+> To establish association Releaser will set itself to `metadata.labels."reclaimable-pv-releaser.kubernetes.io/managed-by"` on this PV.
+
+As disclaimed - that approach was error prone. It was fine most of the time, but if Releaser was down for any noticeable duration of time - it was resulting in PVs piling up in `Released` state, and as the PVC was long gone by then - PVs would remain in that state forever, until manually cleared up.
+
+This mechanism of association through PVC was removed in this release and replaced with a simple Storage Class annotation. In order for Releaser to turn `Released` PV as `Available` - its Storage Class must be annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing at the `-controller-id` of this Releaser. It can now retro-actively release PVs on startup that it never received events about. As a side effect - `-controller-id` of Provisioner and Releaser doesn't have to match anymore. This unfortunately requires that you use dedicated Storage Class for PVs that must be reclaimable, but that is a fair price to pay if the alternative is unreliable and error prone and might result in expensive storage bills.
+
+You must use Helm charts version `v0.1.0` or above as RBAC is changed in this release to allow read-only access to Storage Classes.
+
+### Changed
+
+- Old PV association via PVC mechanism was removed
+- `-disable-automatic-association` option on Releaser was removed
+- PVs will only be released now if their Storage Class annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing at the `-controller-id` of this Releaser
+
 ## [0.1.1] - 2022-12-11
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.18 AS build
 ARG RELEASE_STRING=dev
 ENV IMPORT_PATH="github.com/plumber-cd/kubernetes-dynamic-reclaimable-pvc-controllers"
 WORKDIR /go/delivery
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 RUN mkdir bin && go build \
     -ldflags "-X ${IMPORT_PATH}.Version=${RELEASE_STRING}" \

--- a/cmd/reclaimable-pv-releaser/main.go
+++ b/cmd/reclaimable-pv-releaser/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"flag"
+
 	controller "github.com/plumber-cd/kubernetes-dynamic-reclaimable-pvc-controllers"
 	"github.com/plumber-cd/kubernetes-dynamic-reclaimable-pvc-controllers/releaser"
 	clientset "k8s.io/client-go/kubernetes"
@@ -11,9 +11,6 @@ import (
 )
 
 func main() {
-	var disableAutomaticAssociation bool
-	flag.BoolVar(&disableAutomaticAssociation, "disable-automatic-association", false, "disable automatic PV association")
-
 	var c controller.Controller
 	run := func(
 		ctx context.Context,
@@ -23,7 +20,7 @@ func main() {
 		namespace string,
 		controllerId string,
 	) {
-		c = releaser.New(ctx, client, namespace, controllerId, disableAutomaticAssociation)
+		c = releaser.New(ctx, client, namespace, controllerId)
 		if err := c.Run(2, stopCh); err != nil {
 			klog.Fatalf("Error running releaser: %s", err.Error())
 		}

--- a/controller.go
+++ b/controller.go
@@ -286,6 +286,16 @@ func (c *BasicController) Requeue(queue workqueue.RateLimitingInterface, old int
 	c.Enqueue(queue, new)
 }
 
+func (c *BasicController) Forget(queue workqueue.RateLimitingInterface, obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	queue.Forget(key)
+}
+
 func (c *BasicController) RunWorker(
 	name string,
 	queue workqueue.RateLimitingInterface,

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,10 +11,17 @@ nerdctl -n k8s.io build -t kubernetes-dynamic-reclaimable-pvc-controllers:dev .
 2. Deploy
 
 ```bash
+# Create SC
+kubectl apply -f ./examples/basic/sc.yaml
+
 helm repo add plumber-cd https://plumber-cd.github.io/helm/
 helm repo update
 helm install provisioner plumber-cd/dynamic-pvc-provisioner -f ./examples/basic/values.yaml
 helm install releaser plumber-cd/reclaimable-pv-releaser -f ./examples/basic/values.yaml
+
+# Or - using local
+helm install provisioner ../helm/charts/dynamic-pvc-provisioner -f ./examples/basic/values.yaml
+helm install releaser ../helm/charts/reclaimable-pv-releaser -f ./examples/basic/values.yaml
 
 # Check it came up
 kubectl logs deployment/provisioner-dynamic-pvc-provisioner
@@ -24,6 +31,12 @@ kubectl logs deployment/releaser-reclaimable-pv-releaser
 3. Test
 
 ```bash
+# Delete SC and see it is forgotten
+kubectl delete -f ./examples/basic/sc.yaml
+kubectl logs deployment/releaser-reclaimable-pv-releaser
+kubectl get events
+
+# Test provisioner
 kubectl apply -f ./examples/basic/sc.yaml
 kubectl apply -f ./examples/basic/pod.yaml
 
@@ -33,9 +46,6 @@ kubectl describe pod pod-with-dynamic-reclaimable-pvc
 
 # Check provisioner logs
 kubectl logs deployment/provisioner-dynamic-pvc-provisioner
-
-# Check releaser logs
-kubectl logs deployment/releaser-reclaimable-pv-releaser
 
 # Check PV and PVC
 kubectl get pv
@@ -55,7 +65,6 @@ kubectl get pv
 kubectl apply -f ./examples/basic/pod.yaml
 kubectl describe pod pod-with-dynamic-reclaimable-pvc
 kubectl logs deployment/provisioner-dynamic-pvc-provisioner
-kubectl logs deployment/releaser-reclaimable-pv-releaser
 kubectl delete -f ./examples/basic/pod.yaml
 kubectl logs deployment/releaser-reclaimable-pv-releaser
 ```
@@ -66,4 +75,5 @@ kubectl logs deployment/releaser-reclaimable-pv-releaser
 kubectl delete -f ./examples/basic/sc.yaml
 helm uninstall provisioner
 helm uninstall releaser
+kubectl delete lease provisioner-dynamic-pvc-provisioner releaser-reclaimable-pv-releaser
 ```

--- a/examples/basic/sc.yaml
+++ b/examples/basic/sc.yaml
@@ -2,6 +2,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: reclaimable-storage-class
+  annotations:
+    reclaimable-pv-releaser.kubernetes.io/controller-id: dynamic-reclaimable-pvc-controllers
 provisioner: rancher.io/local-path
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer

--- a/examples/jenkins-kubernetes-plugin-with-build-cache/README.md
+++ b/examples/jenkins-kubernetes-plugin-with-build-cache/README.md
@@ -6,6 +6,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: jenkins-maven-cache
+  annotations:
+    reclaimable-pv-releaser.kubernetes.io/controller-id: dynamic-reclaimable-pvc-controllers
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
@@ -16,6 +18,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: jenkins-golang-cache
+  annotations:
+    reclaimable-pv-releaser.kubernetes.io/controller-id: dynamic-reclaimable-pvc-controllers
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2

--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -4,17 +4,20 @@ package releaser
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	controller "github.com/plumber-cd/kubernetes-dynamic-reclaimable-pvc-controllers"
-	"github.com/plumber-cd/kubernetes-dynamic-reclaimable-pvc-controllers/provisioner"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -23,18 +26,19 @@ import (
 const (
 	AgentName = "reclaimable-pv-releaser"
 
-	LabelBaseName     = AgentName + ".kubernetes.io"
-	LabelManagedByKey = "managed-by"
-	LabelManagedBy    = AgentName + "/" + LabelManagedByKey
+	AnnotationBaseName        = AgentName + ".kubernetes.io"
+	AnnotationControllerIdKey = "controller-id"
+	AnnotationControllerId    = AnnotationBaseName + "/" + AnnotationControllerIdKey
 
-	Associated          = "Associated"
-	MessagePVAssociated = "PV associated successfully"
+	SCAdded          = "Added"
+	MessageSCAdded   = "SC tracking added"
+	SCRemoved        = "Removed"
+	MessageSCRemoved = "SC tracking removed"
+	SCLost           = "Lost"
+	MessageSCLost    = "SC tracking removed (lost)"
 
 	Released          = "Released"
 	MessagePVReleased = "PV released successfully"
-
-	MessageAssociatePV = "error associating PV %s: %s"
-	ErrAssociatePV     = "ErrAssociatePV"
 
 	MessageReleasePV = "error releasing PV %s: %s"
 	ErrReleasePV     = "ErrReleasePV"
@@ -43,11 +47,16 @@ const (
 type Releaser struct {
 	controller.BasicController
 
-	DisableAutomaticAssociation bool
+	SCLister storagelisters.StorageClassLister
+	SCSynced cache.InformerSynced
+	SCQueue  workqueue.RateLimitingInterface
 
 	PVLister corelisters.PersistentVolumeLister
 	PVSynced cache.InformerSynced
 	PVQueue  workqueue.RateLimitingInterface
+
+	managedSCMutex *sync.Mutex
+	managedSCSet   map[string]struct{}
 }
 
 func New(
@@ -55,7 +64,6 @@ func New(
 	kubeClientSet kubernetes.Interface,
 	namespace,
 	controllerId string,
-	disableAutomaticAssociation bool,
 ) controller.Controller {
 	klog.Info("Releaser starting...")
 
@@ -63,23 +71,45 @@ func New(
 		klog.Warningf("Releaser can't run within a namespace as PVs are not namespaced resources - ignoring -namespace=%s and acting in the scope of the cluster", namespace)
 	}
 
-	if disableAutomaticAssociation {
-		klog.Warningf("Automatic PV association is disabled - make sure you label PV manually with '%s: %s' label", LabelManagedBy, controllerId)
-	}
-
 	c := controller.New(ctx, kubeClientSet, "", AgentName, controllerId)
 
+	scInformer := c.KubeInformerFactory.Storage().V1().StorageClasses()
 	pvInformer := c.KubeInformerFactory.Core().V1().PersistentVolumes()
 
 	r := &Releaser{
-		BasicController:             *c,
-		DisableAutomaticAssociation: disableAutomaticAssociation,
-		PVLister:                    pvInformer.Lister(),
-		PVSynced:                    pvInformer.Informer().HasSynced,
-		PVQueue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "PersistentVolumes"),
+		BasicController: *c,
+
+		SCLister: scInformer.Lister(),
+		SCSynced: scInformer.Informer().HasSynced,
+		SCQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StorageClasses"),
+
+		PVLister: pvInformer.Lister(),
+		PVSynced: pvInformer.Informer().HasSynced,
+		PVQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "PersistentVolumes"),
+
+		managedSCMutex: &sync.Mutex{},
+		managedSCSet:   make(map[string]struct{}),
 	}
 
 	klog.V(2).Info("Setting up event handlers")
+
+	scInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.Enqueue(r.SCQueue, obj)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			r.Requeue(r.SCQueue, old, new)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if sc, ok := obj.(*v1.StorageClass); ok {
+				r.Forget(r.SCQueue, obj)
+				r.removeManagedSC(sc)
+				return
+			}
+			klog.Warningf("Received DeleteFunc on %T - skip", obj)
+		},
+	})
+
 	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			r.Enqueue(r.PVQueue, obj)
@@ -98,11 +128,21 @@ func (r *Releaser) Run(threadiness int, stopCh <-chan struct{}) error {
 		stopCh,
 		func(threadiness int, stopCh <-chan struct{}) error {
 			klog.V(2).Info("Waiting for informer caches to sync")
+
+			if ok := cache.WaitForCacheSync(stopCh, r.SCSynced); !ok {
+				return fmt.Errorf("failed to wait for SC caches to sync")
+			}
+
 			if ok := cache.WaitForCacheSync(stopCh, r.PVSynced); !ok {
-				return fmt.Errorf("failed to wait for caches to sync")
+				return fmt.Errorf("failed to wait for PV caches to sync")
 			}
 
 			klog.V(2).Info("Starting workers")
+			go wait.Until(
+				r.RunWorker("sc", r.SCQueue, r.scSyncHandler),
+				time.Second,
+				stopCh,
+			)
 			for i := 0; i < threadiness; i++ {
 				go wait.Until(
 					r.RunWorker("pv", r.PVQueue, r.pvSyncHandler),
@@ -111,9 +151,32 @@ func (r *Releaser) Run(threadiness int, stopCh <-chan struct{}) error {
 				)
 			}
 
+			preExistedSC, err := r.SCLister.List(labels.Everything())
+			if err != nil {
+				// If we can't list pre-existent objects - that would be broken state
+				// It is better to fail fast, this is not expected condition
+				panic(err)
+			}
+			for _, sc := range preExistedSC {
+				r.Enqueue(r.SCQueue, sc)
+			}
+
+			preExistedPV, err := r.PVLister.List(labels.Everything())
+			if err != nil {
+				// If we can't list pre-existent objects - that would be broken state
+				// It is better to fail fast, this is not expected condition
+				panic(err)
+			}
+			for _, pv := range preExistedPV {
+				r.Enqueue(r.PVQueue, pv)
+			}
+
 			return nil
 		},
 		func() {
+			if r.SCQueue != nil {
+				r.SCQueue.ShutDown()
+			}
 			if r.PVQueue != nil {
 				r.PVQueue.ShutDown()
 			}
@@ -125,6 +188,66 @@ func (r *Releaser) Stop() {
 	r.BasicController.Stop()
 	// TODO: Any cleanup logic signaling to not to perform any write operations?
 	klog.Info("Releaser stopped")
+}
+
+func (r *Releaser) addManagedSC(sc *v1.StorageClass) {
+	r.managedSCMutex.Lock()
+	defer r.managedSCMutex.Unlock()
+	if _, exists := r.managedSCSet[sc.ObjectMeta.Name]; exists {
+		return
+	}
+	r.managedSCSet[sc.ObjectMeta.Name] = struct{}{}
+	r.Recorder.Event(sc, corev1.EventTypeNormal, SCAdded, MessageSCAdded)
+}
+
+func (r *Releaser) removeManagedSC(sc *v1.StorageClass) {
+	r.managedSCMutex.Lock()
+	defer r.managedSCMutex.Unlock()
+	if _, exists := r.managedSCSet[sc.ObjectMeta.Name]; !exists {
+		return
+	}
+	delete(r.managedSCSet, sc.ObjectMeta.Name)
+	r.Recorder.Event(sc, corev1.EventTypeNormal, SCRemoved, MessageSCRemoved)
+}
+
+func (r *Releaser) removeMissingSC(name string) {
+	r.managedSCMutex.Lock()
+	defer r.managedSCMutex.Unlock()
+	if _, exists := r.managedSCSet[name]; !exists {
+		return
+	}
+	delete(r.managedSCSet, name)
+	r.Recorder.Event(&corev1.ObjectReference{
+		APIVersion: "storage.k8s.io/v1",
+		Kind:       "StorageClass",
+		Name:       name,
+	}, corev1.EventTypeNormal, SCLost, MessageSCLost)
+}
+
+func (r *Releaser) scSyncHandler(_, name string) error {
+	sc, err := r.SCLister.Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			utilruntime.HandleError(
+				fmt.Errorf("sc '%s' in work queue no longer exists", name),
+			)
+			r.removeMissingSC(name)
+			return nil
+		}
+
+		return err
+	}
+
+	manager, ok := sc.ObjectMeta.Annotations[AnnotationControllerId]
+	if ok {
+		if manager == r.ControllerId {
+			r.addManagedSC(sc)
+			return nil
+		}
+		klog.V(5).Infof("SC %s is not annotated with '%s=%s', skip", sc.ObjectMeta.Name, AnnotationControllerId, r.ControllerId)
+	}
+
+	return nil
 }
 
 func (r *Releaser) pvSyncHandler(_, name string) error {
@@ -140,73 +263,13 @@ func (r *Releaser) pvSyncHandler(_, name string) error {
 		return err
 	}
 
-	manager, ok := pv.ObjectMeta.Labels[LabelManagedBy]
+	_, ok := r.managedSCSet[pv.Spec.StorageClassName]
 	if ok {
-		if manager == r.ControllerId {
-			return r.pvReleaseHandler(pv)
-		}
-		klog.V(5).Infof("PV %s is managed by '%s', not me '%s', skip", pv.ObjectMeta.Name, manager, r.ControllerId)
-	} else if !r.DisableAutomaticAssociation {
-		return r.pvAssociateHandler(pv)
+		return r.pvReleaseHandler(pv)
+	} else {
+		klog.V(5).Infof("SC %q for PV %q is not associated with this controller ID %q, skip", pv.Spec.StorageClassName, pv.ObjectMeta.Name, r.ControllerId)
 	}
 
-	return nil
-}
-
-func (r *Releaser) pvAssociateHandler(pv *corev1.PersistentVolume) error {
-	if pv.Spec.ClaimRef == nil {
-		klog.V(5).Infof("PV %s had no claim ref, skip", pv.ObjectMeta.Name)
-		return nil
-	}
-
-	pvc, err := r.KubeClientSet.CoreV1().PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).
-		Get(r.Ctx, pv.Spec.ClaimRef.Name, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			klog.V(5).Infof("PV %s had claim ref to the void, skip", pv.ObjectMeta.Name)
-			return nil
-		}
-
-		return err
-	}
-
-	pvcReleaserOwner, releaserOwnerOk := pvc.ObjectMeta.Labels[LabelManagedBy]
-	pvcProvisionerOwner, provisionerOwnerOk := pvc.ObjectMeta.Labels[provisioner.LabelManagedBy]
-	if !provisionerOwnerOk && !releaserOwnerOk {
-		klog.V(5).Infof("PVC has no manager, skip PV %s", pvc.ObjectMeta.Name, pv.ObjectMeta.Name)
-		return nil
-	} else if releaserOwnerOk && pvcReleaserOwner != r.ControllerId {
-		klog.V(5).Infof("PVC %s is managed by releaser '%s', not me '%s', skip PV %s", pvc.ObjectMeta.Name, pvcReleaserOwner, r.ControllerId, pv.ObjectMeta.Name)
-		return nil
-	} else if provisionerOwnerOk && pvcProvisionerOwner != r.ControllerId {
-		klog.V(5).Infof("PVC %s is managed by provisioner '%s', not me '%s', skip PV %s", pvc.ObjectMeta.Name, pvcProvisionerOwner, r.ControllerId, pv.ObjectMeta.Name)
-		return nil
-	}
-
-	klog.V(4).Infof("PV %s is matched for association based on PVC %s", pv.ObjectMeta.Name, pvc.ObjectMeta.Name)
-
-	pvCopy := pv.DeepCopy()
-	if pvCopy.ObjectMeta.Labels == nil {
-		pvCopy.ObjectMeta.Labels = make(map[string]string)
-	}
-	pvCopy.ObjectMeta.Labels[LabelManagedBy] = r.ControllerId
-	_, err = r.KubeClientSet.CoreV1().PersistentVolumes().Update(r.Ctx, pvCopy, metav1.UpdateOptions{})
-	if err != nil {
-		if errors.IsConflict(err) {
-			klog.V(4).Infof("PV %s had a conflict - ignore it, it will be queued again with a new version", pv.ObjectMeta.Name)
-			return nil
-		}
-
-		r.Recorder.Event(
-			pvCopy,
-			corev1.EventTypeWarning,
-			ErrAssociatePV,
-			fmt.Sprintf(MessageAssociatePV, pvCopy, err),
-		)
-		return err
-	}
-
-	r.Recorder.Event(pv, corev1.EventTypeNormal, Associated, MessagePVAssociated)
 	return nil
 }
 
@@ -218,10 +281,6 @@ func (r *Releaser) pvReleaseHandler(pv *corev1.PersistentVolume) error {
 
 	pvCopy := pv.DeepCopy()
 	pvCopy.Spec.ClaimRef = nil
-	if !r.DisableAutomaticAssociation {
-		klog.V(4).Infof("Removing PV %s association with myself ('%s')", pv.ObjectMeta.Name, r.ControllerId)
-		delete(pvCopy.ObjectMeta.Labels, LabelManagedBy)
-	}
 	_, err := r.KubeClientSet.CoreV1().PersistentVolumes().Update(r.Ctx, pvCopy, metav1.UpdateOptions{})
 	if err != nil {
 		if errors.IsConflict(err) {


### PR DESCRIPTION
### BREAKING CHANGES

Prior to this change, one of the features of Releaser was to "Automatically associates Releaser with PVs claimed by PVCs that were created by Provisioner with the same `--controller-id`".
From the `README.md` prior to this change:

> ## PV Releaser Controller
> 
> For Releaser to be able to make PVs claimed by Provisioner `Available` after PVC is gone - Releaser and Provisioner must share the same Controller ID.
> 
> ### Associate
> 
> Once `Released` - PVs doesn't have any indication that they were once associated with a PVC that had association with this Controller ID. To establish this relation - we must catch it while PVC still exists and mark it with our label. If Releaser was down the whole time PVC existed - PV could never be associated making it now orphaned and it will stay as `Released` - Releaser can't know it have to make it `Available`.
> 
> Releaser listens for PV creations/updates.
> The following conditions must be met for a PV to be associated with a Releaser:
> 
> - PV doesn't already have `metadata.labels."reclaimable-pv-releaser.kubernetes.io/managed-by"` association.
> - `spec.claimRef` must refer to a PVC that either has `metadata.labels."dynamic-pvc-provisioner.kubernetes.io/managed-by"` or `reclaimable-pv-releaser.kubernetes.io/managed-by` set to this Controller ID. If both labels are set - both should point to this Controller ID.
> - `--disable-automatic-association` must be `false`.
> 
> To establish association Releaser will set itself to `metadata.labels."reclaimable-pv-releaser.kubernetes.io/managed-by"` on this PV.

As disclaimed - that approach was error prone. It was fine most of the time, but if Releaser was down for any noticeable duration of time - it was resulting in PVs piling up in `Released` state, and as the PVC was long gone by then - PVs would remain in that state forever, until manually cleared up.

This mechanism of association through PVC was removed in this release and replaced with a simple Storage Class annotation. In order for Releaser to turn `Released` PV as `Available` - its Storage Class must be annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing at the `-controller-id` of this Releaser. It can now retro-actively release PVs on startup that it never received events about. As a side effect - `-controller-id` of Provisioner and Releaser doesn't have to match anymore. This unfortunately requires that you use dedicated Storage Class for PVs that must be reclaimable, but that is a fair price to pay if the alternative is unreliable and error prone and might result in expensive storage bills.

You must use Helm charts version `v0.1.0` or above as RBAC is changed in this release to allow read-only access to Storage Classes.

### Changed

- Old PV association via PVC mechanism was removed
- `-disable-automatic-association` option on Releaser was removed
- PVs will only be released now if their Storage Class annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing at the `-controller-id` of this Releaser