### PR TITLE
Multiple fixes after testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2022-12-12
+
+### Fixed
+
+- Regression in `v0.2.0` - it was correct to use non-rate limited functions in certain scenarios, rate limit should only be used for retry after errors
+- Retry in case of errors was broken - it was using `Forget` instead of `Done` which was just resetting the rate limit counter but not actually removing previous item from the queue
+- No longer watch for SC - lister is already using efficient caching API, so it is cheap to get a SC by name from the Index during PV reconciliation; that removes some race condition when PV was reconciled and forgotten about before Releaser learned that SC is annotated
+- Do nor re-queue an object that has the same version
+- There was race conditions when `claimRef` was already removed from the PV but Kubernetes didn't yet marked it as `Available`, re-queuing such a PV was resulting in duplicative `Released` events - now Released verifies that the `claimRef` is not already `nil` before trying to release the volume
+
 ## [0.2.1] - 2022-12-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression in `v0.2.0` - it was correct to use non-rate limited functions in certain scenarios, rate limit should only be used for retry after errors
 - Retry in case of errors was broken - it was using `Forget` instead of `Done` which was just resetting the rate limit counter but not actually removing previous item from the queue
 - No longer watch for SC - lister is already using efficient caching API, so it is cheap to get a SC by name from the Index during PV reconciliation; that removes some race condition when PV was reconciled and forgotten about before Releaser learned that SC is annotated
-- Do nor re-queue an object that has the same version
+- Do not re-queue an object that has the same version
 - There was race conditions when `claimRef` was already removed from the PV but Kubernetes didn't yet marked it as `Available`, re-queuing such a PV was resulting in duplicative `Released` events - now Released verifies that the `claimRef` is not already `nil` before trying to release the volume
+- De-queue objects that are deleted from the cluster
 
 ## [0.2.1] - 2022-12-11
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Dynamic PVC provisioner for pods requesting it via annotations. Automatic PV rel
   - Dynamically create PVC for Pods requesting it via the annotations.
   - Pod is automatically set as `ownerReferences` to the PVC - guaranteeing its deletions upon Pod deletion.
 - PV Releaser
-  - Keeps track of Storage Classes marked by annotation pointing to the same `--controller-id`.
-  - Deletes `claimRef` from PVs associated with Releaser (via Storage Class annotation) to move their status from `Released` to `Available` **without deleting any data**.
+  - Deletes `claimRef` from PVs associated with Releaser (via Storage Class annotation that is pointing to the same `--controller-id`) to move their status from `Released` to `Available` **without deleting any data**.
 - Provisioner and Releaser are two separate controllers under one roof, and they can be deployed separately.
   - You can use Provisioner alone for something like Jenkins Kubernetes plugin that doesn't allow PVC creation on its own and automate PVC provisioning from the pod requests. Provisioner on its own will not make PVs automatically reclaimable.
   - You can use Releaser alone. That will enable PVCs to automatically reclaim PVs with whatever data left in it from previous consumer.
@@ -175,7 +174,7 @@ For Releaser to be able to make PVs claimed by Provisioner `Available` after PVC
 
 ### Associate
 
-Releaser listens for Storage Classes and remembers these that are annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing to this `-controller-id`. Any PV that is using Storage Class with that annotation is considered associated.
+Releaser considers PVs associated when their Storage Class is annotated with `metadata.annotations."reclaimable-pv-releaser.kubernetes.io/controller-id"` pointing to this `-controller-id`.
 
 ### Release
 

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -84,6 +84,9 @@ func New(
 		UpdateFunc: func(old, new interface{}) {
 			p.Requeue(p.PodsQueue, old, new)
 		},
+		DeleteFunc: func(obj interface{}) {
+			p.Dequeue(p.PodsQueue, obj)
+		},
 	})
 
 	return p


### PR DESCRIPTION
### Fixed

- Regression in `v0.2.0` - it was correct to use non-rate limited functions in certain scenarios, rate limit should only be used for retry after errors
- Retry in case of errors was broken - it was using `Forget` instead of `Done` which was just resetting the rate limit counter but not actually removing previous item from the queue
- No longer watch for SC - lister is already using efficient caching API, so it is cheap to get a SC by name from the Index during PV reconciliation; that removes some race condition when PV was reconciled and forgotten about before Releaser learned that SC is annotated
- Do not re-queue an object that has the same version
- There was race conditions when `claimRef` was already removed from the PV but Kubernetes didn't yet marked it as `Available`, re-queuing such a PV was resulting in duplicative `Released` events - now Released verifies that the `claimRef` is not already `nil` before trying to release the volume
- De-queue objects that are deleted from the cluster